### PR TITLE
Новые методы, классы, исправления

### DIFF
--- a/src/Api/Entities/Forward.php
+++ b/src/Api/Entities/Forward.php
@@ -6,11 +6,11 @@ use Fastik1\Vkfast\Api\VkApi;
 
 class Forward extends BaseEntity
 {
-    private int $peer_id;
-    private bool $is_reply;
-    private ?int $owner_id;
-    private array $conversation_message_ids = [];
-    private array $message_ids = [];
+    public int $peer_id;
+    public bool $is_reply;
+    public ?int $owner_id;
+    public array $conversation_message_ids = [];
+    public array $message_ids = [];
 
     public function __construct(int $peer_id, bool $is_reply = false, ?int $owner_id = null)
     {

--- a/src/Bot/Configuration/ActionConfiguration.php
+++ b/src/Bot/Configuration/ActionConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fastik1\Vkfast\Bot\Configuration;
+
+use Closure;
+
+class ActionConfiguration extends Configuration
+{
+    public ?string $class = null;
+    public ?string $method = null;
+    public ?Closure $callback = null;
+
+    public function __construct(?string $class = null, ?string $method = null, ?Closure $callback = null)
+    {
+        $this->class = $class;
+        $this->method = $method;
+        $this->callback = $callback;
+    }
+}

--- a/src/Bot/Configuration/CommandConfiguration.php
+++ b/src/Bot/Configuration/CommandConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fastik1\Vkfast\Bot\Configuration;
+
+use Fastik1\Vkfast\Bot\Commands\BaseCommand;
+
+class CommandConfiguration extends Configuration
+{
+    public string|array $name;
+    public string $path;
+    public ?BaseCommand $class = null;
+
+    public function __construct(array|string $name, string $path, ?BaseCommand $class = null)
+    {
+        $this->name = $name;
+        $this->path = $path;
+        $this->class = $class;
+    }
+}

--- a/src/Bot/Configuration/Configuration.php
+++ b/src/Bot/Configuration/Configuration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Fastik1\Vkfast\Bot\Configuration;
+
+class Configuration
+{
+
+}

--- a/src/Bot/Configuration/HandlerConfiguration.php
+++ b/src/Bot/Configuration/HandlerConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Fastik1\Vkfast\Bot\Configuration;
+
+use Closure;
+
+class HandlerConfiguration extends Configuration
+{
+    public string $eventType;
+    public ActionConfiguration $action;
+    public array $rules = [];
+    public ?CommandConfiguration $command = null;
+    public bool $continueProcessing = false;
+
+    public function __construct(string $eventType, Closure|array $action)
+    {
+        $this->eventType = $eventType;
+        $this->action = is_callable($action) ? new ActionConfiguration(callback: $action) : new ActionConfiguration($action[0], $action[1]);
+    }
+}

--- a/src/Bot/Configuration/HandlerConfiguration.php
+++ b/src/Bot/Configuration/HandlerConfiguration.php
@@ -3,6 +3,8 @@
 namespace Fastik1\Vkfast\Bot\Configuration;
 
 use Closure;
+use Fastik1\Vkfast\Bot\Commands\BaseCommand;
+use Fastik1\Vkfast\Bot\Rules\BaseRule;
 
 class HandlerConfiguration extends Configuration
 {
@@ -16,5 +18,30 @@ class HandlerConfiguration extends Configuration
     {
         $this->eventType = $eventType;
         $this->action = is_callable($action) ? new ActionConfiguration(callback: $action) : new ActionConfiguration($action[0], $action[1]);
+    }
+
+    public function rule(BaseRule|array $rule): self
+    {
+        if (is_array($rule)) {
+            foreach ($rule as $items) {
+                $this->rules[] = $items;
+            }
+        } else {
+            $this->rules[] = $rule;
+        }
+
+        return $this;
+    }
+
+    public function command(string|array $commands, string $path = 'object.message.text', BaseCommand|null $classCommand = null): self
+    {
+        $this->command = new CommandConfiguration($commands, $path, $classCommand);
+        return $this;
+    }
+
+    public function continueProcessing(): self
+    {
+        $this->continueProcessing = true;
+        return $this;
     }
 }

--- a/src/Bot/Events/MessageNew.php
+++ b/src/Bot/Events/MessageNew.php
@@ -13,8 +13,23 @@ use Fastik1\Vkfast\Api\Keyboard\Keyboard;
  */
 class MessageNew extends Event
 {
-    public function answer(string|int $message, ?Keyboard $keyboard = null, ?Forward $forward = null, bool $mentions = false, ?string $attachment = null, ...$arguments): mixed
+    public function answer(string|int $message, ?Keyboard $keyboard = null, ?Forward $forward = null, bool $mentions = false, ?string $attachment = null, ?bool $is_reply = false, ...$arguments): mixed
     {
+        if ($is_reply) {
+            $forward = new Forward($this->message->peer_id, true);
+
+            if ($this->message->from_id == $this->message->peer_id) {
+                $forward->addMessageId($this->message->id);
+            } else {
+                $forward->addConversationMessageId($this->message->conversation_message_id);
+            }
+        }
+
         return $this->api->sendMessage($this->message->peer_id, $message, $keyboard, $forward, $mentions, $attachment, ...$arguments);
+    }
+
+    public function reply(string|int $message, ?Keyboard $keyboard = null, ?Forward $forward = null, bool $mentions = false, ?string $attachment = null, ...$arguments): mixed
+    {
+        return $this->answer($message, $keyboard, $forward, $mentions, $attachment, true, ...$arguments);
     }
 }

--- a/src/Bot/VkBot.php
+++ b/src/Bot/VkBot.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Fastik1\Vkfast\Api\VkApi;
 use Fastik1\Vkfast\Bot\Commands\BaseCommand;
+use Fastik1\Vkfast\Bot\Configuration\HandlerConfiguration;
 use Fastik1\Vkfast\Bot\Events\Event;
 use Fastik1\Vkfast\Bot\Events\MessageNew;
 use Fastik1\Vkfast\Bot\Rules\BaseRule;
@@ -30,6 +31,7 @@ class VkBot
     public function on(string $eventClass, Closure|Array $action): self
     {
         array_push($this->handlers, ['event' => $eventClass, 'action' => $action]);
+        $this->handlers = new HandlerConfiguration()
         return $this;
     }
 

--- a/src/Bot/VkBot.php
+++ b/src/Bot/VkBot.php
@@ -28,9 +28,9 @@ class VkBot
         $this->api = $api;
     }
 
-    public function on(string $eventClass, Closure|Array $action): HandlerConfiguration
+    public function on(string $eventType, Closure|Array $action): HandlerConfiguration
     {
-        $handlerConfiguration = new HandlerConfiguration($eventClass, $action);
+        $handlerConfiguration = new HandlerConfiguration($eventType, $action);
         $this->handlers[] = $handlerConfiguration;
         return $handlerConfiguration;
     }
@@ -73,8 +73,7 @@ class VkBot
             $classEvent = Event::class;
         }
 
-        $event = new $classEvent($this->api);
-        $event = $this->fillEvent($event, $rawEvent);
+        $event = $this->fillEvent(new $classEvent($this->api), $rawEvent);
 
         $this->processHandlers($event, $rawEvent);
     }
@@ -92,10 +91,10 @@ class VkBot
 
     private function processHandlers(Event $event, object $rawEvent): void
     {
-        $is_not_continue_processing_handler_found = false;
+        $isNotContinueProcessingHandlerFound = false;
 
         foreach ($this->handlers as $handler) {
-            if ($is_not_continue_processing_handler_found === true) {
+            if ($isNotContinueProcessingHandlerFound === true) {
                 if (!$handler->continueProcessing) {
                     continue;
                 }
@@ -124,16 +123,16 @@ class VkBot
                     }
                 }
 
-                $callback_parameters = [$event, $commandData['command'], ...$commandData['arguments']];
+                $callbackParameters = [$event, $commandData['command'], ...$commandData['arguments']];
             } else {
-                $callback_parameters = [$event];
+                $callbackParameters = [$event];
             }
 
             if (!$handler->continueProcessing) {
-                $is_not_continue_processing_handler_found = true;
+                $isNotContinueProcessingHandlerFound = true;
             }
 
-            $callback = $this->runHandler($handler, $callback_parameters);
+            $callback = $this->runHandler($handler, $callbackParameters);
 
             if (!is_null($callback)) {
                 $this->response((string) $callback);
@@ -145,15 +144,15 @@ class VkBot
         $this->ok();
     }
 
-    private function runHandler(HandlerConfiguration $handler, array $callback_parameters): mixed
+    private function runHandler(HandlerConfiguration $handler, array $callbackParameters): mixed
     {
         try {
             if ($handler->action->callback) {
-                $callback = ($handler->action->callback)(...$callback_parameters);
+                $callback = ($handler->action->callback)(...$callbackParameters);
             } else {
                 $classHandler = new $handler->action->class;
                 $methodHandler = $handler->action->method;
-                $callback = $classHandler->$methodHandler(...$callback_parameters);
+                $callback = $classHandler->$methodHandler(...$callbackParameters);
             }
         } catch (VkApiError $exception) {
             throw new VkApiError($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Bot/VkBot.php
+++ b/src/Bot/VkBot.php
@@ -14,10 +14,13 @@ use Fastik1\Vkfast\Exceptions\VkApiError;
 use Fastik1\Vkfast\Exceptions\VkBotException;
 use Fastik1\Vkfast\Bot\Rules\IsChatMessageBaseRule;
 use Fastik1\Vkfast\Bot\Rules\IsPrivateMessageBaseRule;
+use Fastik1\Vkfast\Traits\AttrubuteHandlers;
 use Fastik1\Vkfast\Utils;
 
 class VkBot
 {
+    use AttrubuteHandlers;
+
     public VkApi $api;
     private array $handlers = [];
     private string $secret = '';
@@ -31,7 +34,8 @@ class VkBot
     public function on(string $eventType, Closure|Array $action): HandlerConfiguration
     {
         $handlerConfiguration = new HandlerConfiguration($eventType, $action);
-        $this->handlers[] = $handlerConfiguration;
+        $attrubuteHandlersName = Utils::eventTypeToAttributeName(Utils::classNameToEvent($eventType));
+        $this->$attrubuteHandlersName[] = $handlerConfiguration;
         return $handlerConfiguration;
     }
 
@@ -92,8 +96,9 @@ class VkBot
     private function processHandlers(Event $event, object $rawEvent): void
     {
         $isNotContinueProcessingHandlerFound = false;
+        $attrubuteHandlersName = Utils::eventTypeToAttributeName($event->type);
 
-        foreach ($this->handlers as $handler) {
+        foreach ($this->$attrubuteHandlersName as $handler) {
             if ($isNotContinueProcessingHandlerFound === true) {
                 if (!$handler->continueProcessing) {
                     continue;

--- a/src/Bot/VkBot.php
+++ b/src/Bot/VkBot.php
@@ -39,22 +39,19 @@ class VkBot
         return $handlerConfiguration;
     }
 
-    public function message(Closure|Array $action): self
+    public function message(Closure|Array $action): HandlerConfiguration
     {
-        $this->on(MessageNew::class, $action);
-        return $this;
+        return $this->on(MessageNew::class, $action);
     }
 
-    public function privateMessage(Closure|Array $action): self
+    public function privateMessage(Closure|Array $action): HandlerConfiguration
     {
-        $this->on(MessageNew::class, $action)->rule(new IsPrivateMessageBaseRule());
-        return $this;
+        return $this->on(MessageNew::class, $action)->rule(new IsPrivateMessageBaseRule());
     }
 
-    public function chatMessage(Closure|Array $action): self
+    public function chatMessage(Closure|Array $action): HandlerConfiguration
     {
-        $this->on(MessageNew::class, $action)->rule(new IsChatMessageBaseRule());
-        return $this;
+        return $this->on(MessageNew::class, $action)->rule(new IsChatMessageBaseRule());
     }
 
     public function run(array|object|null $rawEvent = null): void

--- a/src/Traits/AttrubuteHandlers.php
+++ b/src/Traits/AttrubuteHandlers.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Fastik1\Vkfast\Traits;
+
+trait AttrubuteHandlers
+{
+    public array $handlers_app_payload = [];
+    public array $handlers_audio_new = [];
+    public array $handlers_board_post_delete = [];
+    public array $handlers_board_post_edit = [];
+    public array $handlers_board_post_new = [];
+    public array $handlers_board_post_restore = [];
+    public array $handlers_confirmation = [];
+    public array $handlers_donut_money_withdraw = [];
+    public array $handlers_donut_money_withdraw_error = [];
+    public array $handlers_donut_subscription_cancelled = [];
+    public array $handlers_donut_subscription_create = [];
+    public array $handlers_donut_subscription_expired = [];
+    public array $handlers_donut_subscription_price_changed = [];
+    public array $handlers_donut_subscription_prolonged = [];
+    public array $handlers_event = [];
+    public array $handlers_group_change_photo = [];
+    public array $handlers_group_change_settings = [];
+    public array $handlers_group_join = [];
+    public array $handlers_group_leave = [];
+    public array $handlers_group_officers_edit = [];
+    public array $handlers_like_add = [];
+    public array $handlers_like_remove = [];
+    public array $handlers_market_comment_delete = [];
+    public array $handlers_market_comment_edit = [];
+    public array $handlers_market_comment_new = [];
+    public array $handlers_market_comment_restore = [];
+    public array $handlers_market_order_edit = [];
+    public array $handlers_market_order_new = [];
+    public array $handlers_message_allow = [];
+    public array $handlers_message_deny = [];
+    public array $handlers_message_edit = [];
+    public array $handlers_message_event = [];
+    public array $handlers_message_new = [];
+    public array $handlers_message_reaction_eve = [];
+    public array $handlers_message_read = [];
+    public array $handlers_message_reply = [];
+    public array $handlers_message_typing_state = [];
+    public array $handlers_photo_comment_delete = [];
+    public array $handlers_photo_comment_edit = [];
+    public array $handlers_photo_comment_new = [];
+    public array $handlers_photo_comment_restor = [];
+    public array $handlers_photo_new = [];
+    public array $handlers_poll_vote_new = [];
+    public array $handlers_user_block = [];
+    public array $handlers_user_unblock = [];
+    public array $handlers_video_comment_delete = [];
+    public array $handlers_video_comment_edit = [];
+    public array $handlers_video_comment_new = [];
+    public array $handlers_video_comment_restor = [];
+    public array $handlers_video_new = [];
+    public array $handlers_vkpay_transaction = [];
+    public array $handlers_wall_post_new = [];
+    public array $handlers_wall_reply_delete = [];
+    public array $handlers_wall_reply_edit = [];
+    public array $handlers_wall_reply_new = [];
+    public array $handlers_wall_reply_restore = [];
+    public array $handlers_wall_repost = [];
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -39,4 +39,9 @@ class Utils
         $string = strtolower($string);
         return $string;
     }
+
+    public static function eventTypeToAttributeName(string $eventType): string
+    {
+        return 'handlers_' . $eventType;
+    }
 }

--- a/tests/VkBotTest.php
+++ b/tests/VkBotTest.php
@@ -95,11 +95,9 @@ class VkBotTest extends TestCase
      */
     public function test_on_method()
     {
-        $this->assertCount(0, $this->bot->getHandlers());
-
         $this->bot->on(MessageNew::class, function (MessageNew $event) {});
 
-        $this->assertCount(1, $this->bot->getHandlers());
+        $this->assertCount(1, $this->bot->handlers_message_new);
     }
 
     /**
@@ -110,7 +108,7 @@ class VkBotTest extends TestCase
     {
         $this->bot->message(function (MessageNew $event) {});
 
-        $this->assertEmpty($this->bot->getHandlers()[0]->rules);
+        $this->assertEmpty($this->bot->handlers_message_new[0]->rules);
     }
 
     /**
@@ -121,10 +119,10 @@ class VkBotTest extends TestCase
     {
         $this->bot->privateMessage(function (MessageNew $event) {});
 
-        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
+        $this->assertNotEmpty($this->bot->handlers_message_new[0]->rules);
 
         $is_finded_rule = false;
-        foreach ($this->bot->getHandlers()[0]->rules as $rule) {
+        foreach ($this->bot->handlers_message_new[0]->rules as $rule) {
             if (IsPrivateMessageBaseRule::class == $rule::class) {
                 $is_finded_rule = true;
             }
@@ -140,10 +138,10 @@ class VkBotTest extends TestCase
     {
         $this->bot->chatMessage(function (MessageNew $event) {});
 
-        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
+        $this->assertNotEmpty($this->bot->handlers_message_new[0]->rules);
 
         $is_found_rule = false;
-        foreach ($this->bot->getHandlers()[0]->rules as $rule) {
+        foreach ($this->bot->handlers_message_new[0]->rules as $rule) {
             if (IsChatMessageBaseRule::class == $rule::class) {
                 $is_found_rule = true;
             }
@@ -167,9 +165,9 @@ class VkBotTest extends TestCase
         $test_is_call_3 = false;
         $this->bot->on(MessageNew::class, function (MessageNew $event) use (&$test_is_call_3) {$test_is_call_3 = true;}); // необязательный обработчик, который уже не сработает, т.к. сработал первый обработчик
 
-        $this->assertFalse($this->bot->getHandlers()[0]->continueProcessing);
-        $this->assertTrue($this->bot->getHandlers()[1]->continueProcessing);
-        $this->assertFalse($this->bot->getHandlers()[2]->continueProcessing);
+        $this->assertFalse($this->bot->handlers_message_new[0]->continueProcessing);
+        $this->assertTrue($this->bot->handlers_message_new[1]->continueProcessing);
+        $this->assertFalse($this->bot->handlers_message_new[2]->continueProcessing);
 
         $this->bot->run($this->event_message_new);
 
@@ -432,8 +430,8 @@ class VkBotTest extends TestCase
         $this->bot->on(MessageNew::class, function () {})
             ->rule(new IsPrivateMessageBaseRule);
 
-        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
-        $this->assertInstanceOf(IsPrivateMessageBaseRule::class, $this->bot->getHandlers()[0]->rules[0]);
+        $this->assertNotEmpty($this->bot->handlers_message_new[0]->rules);
+        $this->assertInstanceOf(IsPrivateMessageBaseRule::class, $this->bot->handlers_message_new[0]->rules[0]);
     }
 
     /**

--- a/tests/VkBotTest.php
+++ b/tests/VkBotTest.php
@@ -104,33 +104,27 @@ class VkBotTest extends TestCase
 
     /**
      * Тест на добавление нового события "message_new" с помощью хелпера message() для обработки всех событий данного типа
-     * Порядок проверки: отсутствие событий, добавилось ли событие, отсутствие доп. правил (rules) для добавленного события
+     * Порядок проверки: отсутствие доп. правил (rules) для добавленного события
      */
     public function test_message_method()
     {
-        $this->assertCount(0, $this->bot->getHandlers());
-
         $this->bot->message(function (MessageNew $event) {});
 
-        $this->assertCount(1, $this->bot->getHandlers());
-        $this->assertArrayNotHasKey('rules', $this->bot->getHandlers()[0]);
+        $this->assertEmpty($this->bot->getHandlers()[0]->rules);
     }
 
     /**
      * Тест на добавление нового события "message_new" с помощью хелпера privateMessage() только для обработки личных сообщений
-     * Порядок проверки: отсутствие событий, добавилось ли событие, наличие правил (rules), наличие правила IsPrivateMessageRule
+     * Порядок проверки: наличие правил (rules), наличие правила IsPrivateMessageRule
      */
     public function test_privateMessage_method()
     {
-        $this->assertCount(0, $this->bot->getHandlers());
-
         $this->bot->privateMessage(function (MessageNew $event) {});
 
-        $this->assertCount(1, $this->bot->getHandlers());
-        $this->assertArrayHasKey('rules', $this->bot->getHandlers()[0]);
+        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
 
         $is_finded_rule = false;
-        foreach ($this->bot->getHandlers()[0]['rules'] as $rule) {
+        foreach ($this->bot->getHandlers()[0]->rules as $rule) {
             if (IsPrivateMessageBaseRule::class == $rule::class) {
                 $is_finded_rule = true;
             }
@@ -140,19 +134,16 @@ class VkBotTest extends TestCase
 
     /**
      * Тест на добавление нового события "message_new" с помощью хелпера privateMessage() только для обработки сообщений из чата
-     * Порядок проверки: отсутствие событий, добавилось ли событие, наличие правил (rules), наличие правила IsChatMessageRule
+     * Порядок проверки: наличие правил (rules), наличие правила IsChatMessageRule
      */
     public function test_chatMessage_method()
     {
-        $this->assertCount(0, $this->bot->getHandlers());
-
         $this->bot->chatMessage(function (MessageNew $event) {});
 
-        $this->assertCount(1, $this->bot->getHandlers());
-        $this->assertArrayHasKey('rules', $this->bot->getHandlers()[0]);
+        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
 
         $is_found_rule = false;
-        foreach ($this->bot->getHandlers()[0]['rules'] as $rule) {
+        foreach ($this->bot->getHandlers()[0]->rules as $rule) {
             if (IsChatMessageBaseRule::class == $rule::class) {
                 $is_found_rule = true;
             }
@@ -176,11 +167,9 @@ class VkBotTest extends TestCase
         $test_is_call_3 = false;
         $this->bot->on(MessageNew::class, function (MessageNew $event) use (&$test_is_call_3) {$test_is_call_3 = true;}); // необязательный обработчик, который уже не сработает, т.к. сработал первый обработчик
 
-        $this->assertCount(3, $this->bot->getHandlers());
-        $this->assertArrayNotHasKey('continue_processing', $this->bot->getHandlers()[0]);
-        $this->assertArrayHasKey('continue_processing', $this->bot->getHandlers()[1]);
-        $this->assertArrayNotHasKey('continue_processing', $this->bot->getHandlers()[2]);
-        $this->assertTrue($this->bot->getHandlers()[1]['continue_processing']);
+        $this->assertFalse($this->bot->getHandlers()[0]->continueProcessing);
+        $this->assertTrue($this->bot->getHandlers()[1]->continueProcessing);
+        $this->assertFalse($this->bot->getHandlers()[2]->continueProcessing);
 
         $this->bot->run($this->event_message_new);
 
@@ -434,7 +423,7 @@ class VkBotTest extends TestCase
 
     /**
      * Тест на добавление правила
-     * Порядок проверки: добавление нового обработчика, наличие внутри массива с правилами, проверка на НЕ пустоту первого правила, проверка на является ли первое правило инстансом добавленного правила
+     * Порядок проверки: проверка на НЕ пустоту массива с правилами, проверка на является ли первое правило инстансом добавленного правила
      */
     public function test_add_rule()
     {
@@ -443,10 +432,8 @@ class VkBotTest extends TestCase
         $this->bot->on(MessageNew::class, function () {})
             ->rule(new IsPrivateMessageBaseRule);
 
-        $this->assertArrayHasKey(0, $this->bot->getHandlers());
-        $this->assertArrayHasKey('rules', $this->bot->getHandlers()[0]);
-        $this->assertNotEmpty($this->bot->getHandlers()[0]['rules'][0]);
-        $this->assertInstanceOf(IsPrivateMessageBaseRule::class, $this->bot->getHandlers()[0]['rules'][0]);
+        $this->assertNotEmpty($this->bot->getHandlers()[0]->rules);
+        $this->assertInstanceOf(IsPrivateMessageBaseRule::class, $this->bot->getHandlers()[0]->rules[0]);
     }
 
     /**


### PR DESCRIPTION
- Обновлена "внутрянка" класса `VkBot`: рефакторинг и изменение структуры, улучшена производительность
- У класса `Forward` изменена область видимости свойств с `private` на `public`
- У класса `MessageNew` события message_new в метод `->answer()` добавлен параметр `$is_reply`, благодаря которому можно ответить на сообщение, дополнительно переслав(ответив) на него.
- Также, добавлен новый метод `->reply()` туда же, который делает тоже самое, но чуть удобнее (указывать отдельно аргумент `$is_reply` не нужно